### PR TITLE
build with on-the-fly bazel

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,27 @@ if [[ "${target_platform}" == osx-* ]]; then
 else
   export LDFLAGS="${LDFLAGS} -lrt"
 fi
-# source gen-bazel-toolchain
+
+# from bazel-toolchain-feedstock
+export TARGET_SYSTEM="${HOST}"
+if [[ "${target_platform}" == "osx-64" ]]; then
+  export TARGET_LIBC="macosx"
+  export TARGET_CPU="darwin_x86_64"
+  export TARGET_SYSTEM="x86_64-apple-macosx"
+elif [[ "${target_platform}" == "osx-arm64" ]]; then
+  export TARGET_LIBC="macosx"
+  export TARGET_CPU="darwin_arm64"
+  export TARGET_SYSTEM="arm64-apple-macosx"
+elif [[ "${target_platform}" == "linux-64" ]]; then
+  export TARGET_LIBC="unknown"
+  export TARGET_CPU="k8"
+elif [[ "${target_platform}" == "linux-aarch64" ]]; then
+  export TARGET_LIBC="unknown"
+  export TARGET_CPU="aarch64"
+elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
+  export TARGET_LIBC="unknown"
+  export TARGET_CPU="ppc"
+fi
 
 CUSTOM_BAZEL_OPTIONS="--bazel_options=--crosstool_top=//bazel_toolchain:toolchain --bazel_options=--logging=6 --bazel_options=--verbose_failures --bazel_options=--toolchain_resolution_debug"
 
@@ -17,9 +37,9 @@ if [[ "${target_platform}" == "osx-64" ]]; then
 fi
 
 if [[ "${target_platform}" == "osx-arm64" ]]; then
-  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} # --target_cpu ${TARGET_CPU}
+  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} --target_cpu ${TARGET_CPU}
 else
-  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} # --bazel_options=--cpu --bazel_options=${TARGET_CPU}
+  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} --bazel_options=--cpu --bazel_options=${TARGET_CPU}
 fi
 
 # Clean up to speedup postprocessing

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ if [[ "${target_platform}" == osx-* ]]; then
 else
   export LDFLAGS="${LDFLAGS} -lrt"
 fi
-source gen-bazel-toolchain
+# source gen-bazel-toolchain
 
 CUSTOM_BAZEL_OPTIONS="--bazel_options=--crosstool_top=//bazel_toolchain:toolchain --bazel_options=--logging=6 --bazel_options=--verbose_failures --bazel_options=--toolchain_resolution_debug"
 
@@ -17,9 +17,9 @@ if [[ "${target_platform}" == "osx-64" ]]; then
 fi
 
 if [[ "${target_platform}" == "osx-arm64" ]]; then
-  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} --target_cpu ${TARGET_CPU}
+  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} # --target_cpu ${TARGET_CPU}
 else
-  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} --bazel_options=--cpu --bazel_options=${TARGET_CPU}
+  ${PYTHON} build/build.py --target_cpu_features default --enable_mkl_dnn ${CUSTOM_BAZEL_OPTIONS} # --bazel_options=--cpu --bazel_options=${TARGET_CPU}
 fi
 
 # Clean up to speedup postprocessing

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,7 +44,7 @@ fi
 
 # Clean up to speedup postprocessing
 pushd build
-bazel clean
+# bazel clean
 popd
 
 ${PYTHON} -m pip install dist/jaxlib-*.whl

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,7 +29,7 @@ elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
   export TARGET_CPU="ppc"
 fi
 
-CUSTOM_BAZEL_OPTIONS="--bazel_options=--crosstool_top=//bazel_toolchain:toolchain --bazel_options=--logging=6 --bazel_options=--verbose_failures --bazel_options=--toolchain_resolution_debug"
+CUSTOM_BAZEL_OPTIONS="--bazel_options=--bazel_options=--logging=6 --bazel_options=--verbose_failures --bazel_options=--toolchain_resolution_debug"
 
 if [[ "${target_platform}" == "osx-64" ]]; then
   # Tensorflow doesn't cope yet with an explicit architecture (darwin_x86_64) on osx-64 yet.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,7 +29,7 @@ elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
   export TARGET_CPU="ppc"
 fi
 
-CUSTOM_BAZEL_OPTIONS="--bazel_options=--bazel_options=--logging=6 --bazel_options=--verbose_failures --bazel_options=--toolchain_resolution_debug"
+CUSTOM_BAZEL_OPTIONS="--bazel_options=--logging=6 --bazel_options=--verbose_failures --bazel_options=--toolchain_resolution_debug"
 
 if [[ "${target_platform}" == "osx-64" ]]; then
   # Tensorflow doesn't cope yet with an explicit architecture (darwin_x86_64) on osx-64 yet.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - numpy >=1.18                           
     - scipy                                  # [build_platform != target_platform]
     - bazel 4.1.0
+    - git
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - numpy >=1.18                           
     - scipy                                  # [build_platform != target_platform]
-    - bazel 4.2.1
+    - bazel 4.1.0
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,16 +19,16 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - patch
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
+    - numpy >=1.18                           
     - scipy                                  # [build_platform != target_platform]
-    - bazel 4.1.0
-    - bazel-toolchain
+    - bazel 4.2.1
   host:
     - python
     - pip
-    - numpy
+    - numpy >=1.18
     - scipy
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,10 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - numpy >=1.18                           
     - scipy                                  # [build_platform != target_platform]
-    - bazel 4.1.0
+      # the build will download, compile and run its own bazel.
+      # slow, but avoids problems with bazel transitively fetching
+      # archives from non-existent mirrors.
+      # - bazel 4.1.0
     - git
   host:
     - python
@@ -43,6 +46,7 @@ requirements:
 test:
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
   imports:


### PR DESCRIPTION
This will download, compile and build with its own bazel as part of the build, to avoid a missing transitive dependency downloaded by bazel.