### PR TITLE
V0.4.23b1 win support

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,3 +3,5 @@ bazel clean --expunge
 bazel shutdown
 
 %PYTHON% -m pip install --find-links=dist jaxlib --no-build-isolation --no-deps
+
+copy %PREFIX%\Lib\site-packages\jaxlib\mlir\_mlir_libs\*.dll %LIBRARY_BIN%\

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,4 +2,4 @@
 bazel clean --expunge
 bazel shutdown
 
-%PYTHON% -m pip install dist/jaxlib-*.whl --no-build-isolation --no-deps
+%PYTHON% -m pip install --find-links=dist jaxlib --no-build-isolation --no-deps

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,5 @@
+%PYTHON% build/build.py
+bazel clean --expunge
+bazel shutdown
+
+%PYTHON% -m pip install dist/jaxlib-*.whl --no-build-isolation --no-deps

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: e4c06d62ba54becffd91abc862627b8b11b79c5a77366af8843b819665b6d568
 
 build:
-  number: 0
-  # s390x is missing bazel. Win not supported by jaxlib.
-  skip: true  # [s390x or win or py<39]
+  number: 1
+  # s390x is missing bazel.
+  skip: true  # [s390x or py<39]
 
 requirements:
   build:
@@ -30,7 +30,7 @@ requirements:
     - setuptools
     - numpy 1.22.*  # [py<311]
     - numpy 1.23.*  # [py==311]
-    - numpy 1.26.*  # [py==312]
+    - numpy 1.26.*  # [py>=312]
     - python-build
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L207
     # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L98
     - bazel >=5.1.1,<7
-    - bazel-toolchain >=0.1.9
+    - bazel-toolchain >=0.1.9  # [not win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,9 @@ requirements:
     - python
     # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L207
     # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L98
-    - bazel >=5.1.1,<7
+    - bazel >=5.1.1,<7  # [not win]
+    # TODO 6.5.0 is currently broken on windows. 10/21/2022
+    - bazel >=5.1.1,<7,!=6.5.0  # [win]
     - bazel-toolchain >=0.1.9  # [not win]
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,7 @@ requirements:
     - python
     # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L207
     # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L98
-    - bazel >=5.1.1,<7  # [not win]
-    # TODO 6.5.0 is currently broken on windows. 10/21/2022
-    - bazel >=5.1.1,<7,!=6.5.0  # [win]
+    - bazel >=5.1.1,<7
     - bazel-toolchain >=0.1.9  # [not win]
   host:
     - python


### PR DESCRIPTION
jaxlib v0.4.23 build 1

Adds windows support. 

**Destination channel:** defaults

### Links

- [PKG-3383](https://anaconda.atlassian.net/browse/PKG-3383) 
- [Upstream repository](https://github.com/jax-ml/jax/blob/jaxlib-v0.4.23/)


### Explanation of changes:

- Bumped build number
- Added Windows build script
- Update numpy pinning to match [upstream](https://github.com/jax-ml/jax/blob/jaxlib-v0.4.23/setup.py#L79)


[PKG-3383]: https://anaconda.atlassian.net/browse/PKG-3383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ