### PR TITLE
Bug fix for naming on cpu packages.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "0.4.35" %}
 {% set name = "jaxlib" %}
 
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}
@@ -25,7 +25,7 @@ build:
   skip: true  # [s390x or py<310]
   skip: true  # [skip_cuda_prefect and (gpu_variant or "").startswith('cuda')]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith('cuda')]
-  string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith('None')]
+  string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith('cpu')]
 
 requirements:
   build:


### PR DESCRIPTION
### Explanation of changes:

- Generate `jaxlib-0.4.35-cpu_py310h12a0925_2.conda` instead of `jaxlib-0.4.35-py310h12a0925_0.conda`

You can verify here: https://staging.continuum.io/prefect/fs/jaxlib-feedstock/pr12/33fa4ab
