### PR TITLE
build v0.4.30

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,1 @@
-aggregate_branch: 3.12
+aggregate_check: false

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,7 @@ build --toolchain_resolution_debug
 build --define=PREFIX=${PREFIX}
 build --define=PROTOBUF_INCLUDE_PATH=${PREFIX}/include
 build --local_cpu_resources=${CPU_COUNT}"
+query "//build:*"
 EOF
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/google/jax/archive/{{ name }}-v{{ version }}.tar.gz
-  sha256: e4c06d62ba54becffd91abc862627b8b11b79c5a77366af8843b819665b6d568
+  sha256: 0ef9635c734d9bbb44fcc87df4f1c3ccce1cfcfd243572c80d36fcdf826fe1e6
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - scipy >=1.11.1  # [py>=312]
     - ml_dtypes >=0.2.0
   run_constrained:
-    - jax >={{ version }}
+    - jax >=0.4.27
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.23" %}
+{% set version = "0.4.30" %}
 {% set name = "jaxlib" %}
 
 package:
@@ -10,7 +10,7 @@ source:
   sha256: e4c06d62ba54becffd91abc862627b8b11b79c5a77366af8843b819665b6d568
 
 build:
-  number: 1
+  number: 0
   # s390x is missing bazel.
   skip: true  # [s390x or py<39]
 


### PR DESCRIPTION
jaxlib 0.4.30

**Destination channel:** defaults

### Links

- [PKG-6693](https://anaconda.atlassian.net/browse/PKG-6693) 
- [Upstream repository](https://github.com/jax-ml/jax/tree/jaxlib-v0.4.30)

### Explanation of changes:

- rebuilt old versioned feedstock at v0.4.30 from v0.4.35 (w/ cuda builds)


[PKG-6693]: https://anaconda.atlassian.net/browse/PKG-6693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ