### PR TITLE
jaxlib 0.4.25

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,1 @@
-aggregate_branch: 3.12
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ about:
   description: |
     jaxlib is the support library for JAX. While JAX itself is a pure Python package, jaxlib contains the binary (C/C++) parts of the library, including Python bindings, the XLA compiler, the PJRT runtime, and a handful of handwritten kernels.
   dev_url: https://github.com/google/jax
-  doc_url: https://jax.readthedocs.io/en/latest/
+  doc_url: https://github.com/jax-ml/jax/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.23" %}
+{% set version = "0.4.25" %}
 {% set name = "jaxlib" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/google/jax/archive/{{ name }}-v{{ version }}.tar.gz
-  sha256: e4c06d62ba54becffd91abc862627b8b11b79c5a77366af8843b819665b6d568
+  url: https://github.com/jax-ml/jax/archive/refs/tags/{{ name }}-v{{ version }}.tar.gz
+  sha256: fc1197c401924942eb14185a61688d0c476e3e81ff71f9dc95e620b57c06eec8
 
 build:
   number: 1
@@ -19,8 +19,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python
-    # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L207
-    # https://github.com/google/jax/blob/jaxlib-v0.4.23/build/build.py#L98
+    # https://github.com/jax-ml/jax/blob/jaxlib-v0.4.25/build/build.py#L217
+    # https://github.com/jax-ml/jax/blob/jaxlib-v0.4.25/build/build.py#L108
     - bazel >=5.1.1,<7
     - bazel-toolchain >=0.1.9  # [not win]
   host:
@@ -28,9 +28,9 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - numpy 1.22.*  # [py<311]
-    - numpy 1.23.*  # [py==311]
-    - numpy 1.26.*  # [py>=312]
+    - numpy >=1.22.* # [py<311]
+    - numpy >=1.23.2  # [py==311]
+    - numpy >=1.26.0  # [py>=312]
     - python-build
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fc1197c401924942eb14185a61688d0c476e3e81ff71f9dc95e620b57c06eec8
 
 build:
-  number: 1
+  number: 0
   # s390x is missing bazel.
   skip: true  # [s390x or py<39]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,9 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - numpy >=1.22.* # [py<311]
-    - numpy >=1.23.2  # [py==311]
-    - numpy >=1.26.0  # [py>=312]
+    - numpy 1.22.*  # [py<311]
+    - numpy 1.23.*  # [py==311]
+    - numpy 1.26.*  # [py>=312]
     - python-build
 
   run:
@@ -64,7 +64,7 @@ about:
   description: |
     jaxlib is the support library for JAX. While JAX itself is a pure Python package, jaxlib contains the binary (C/C++) parts of the library, including Python bindings, the XLA compiler, the PJRT runtime, and a handful of handwritten kernels.
   dev_url: https://github.com/google/jax
-  doc_url: https://jax.readthedocs.io/
+  doc_url: https://jax.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
jaxlib 0.4.25 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6144] 
- [Upstream repository]()
- [Upstream changelog/diff]()

### Explanation of changes:

- build `0.4.25` so we can satisfy `numpyro` for `py39`,`py310`


[PKG-6144]: https://anaconda.atlassian.net/browse/PKG-6144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ