### PR TITLE
jaxlib 0.4.35 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "0.4.35" %}
 {% set name = "jaxlib" %}
 
-{% set build = 2 %}
+{% set build = 3 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}
@@ -67,7 +67,7 @@ requirements:
     - nsync 1.24.0  # [not win]
     - snappy 1.2.1  # [not win]
     - double-conversion 3.1.5  # [not win]
-    - jsoncpp 1.9.4  # [not win]
+    - jsoncpp 1.9.6  # [not win]
     - pybind11 2.13.6  # [not win]
     - libgrpc {{ libgrpc }}  # [not win]
     - libcurl {{ libcurl }}  # [not win]


### PR DESCRIPTION
jaxlib 0.4.35 rebuild

**Destination channel:** Defaults

### Links

- [PKG-9155](https://anaconda.atlassian.net/browse/PKG-9155)
- dev_url:        https://github.com/jax-ml/jax/tree/jax-v0.4.35
- conda_forge:    https://github.com/conda-forge/jaxlib-feedstock
- pypi:
- pypi inspector:

### Explanation of changes:

- rebuild



[PKG-8997]: https://anaconda.atlassian.net/browse/PKG-8997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ