### PR TITLE
Bring back changes from #23

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'jaxlib' %}
 {% set version = "0.9.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}

--- a/recipe/patches/0002-Consolidated-build-fixes-for-XLA.patch
+++ b/recipe/patches/0002-Consolidated-build-fixes-for-XLA.patch
@@ -26,10 +26,10 @@ Co-Authored-By: H. Vetinari <h.vetinari@gmx.com>
  .../0009-Add-macos_x86_64-to-mkl_deps.patch   |  21 +
  .../xla/0010-Add-systemlib-for-oneDNN.patch   | 103 ++++
  ...011-Fix-clang-CUDA-incompatabilities.patch |  64 +++
- .../xla/0013-fix-multiple-definitions.patch   | 122 ++++++
+ .../xla/0013-fix-multiple-definitions.patch   | 120 +++++
  .../0014-Disable-leave-barriers-flag.patch    |  65 +++
  third_party/xla/workspace.bzl                 |  13 +
- 15 files changed, 1697 insertions(+)
+ 15 files changed, 1695 insertions(+)
  create mode 100644 third_party/grpc_systemlib.BUILD
  create mode 100644 third_party/xla/0001-Fix-abseil-headers.patch
  create mode 100644 third_party/xla/0002-Omit-usage-of-StrFormat.patch
@@ -1621,54 +1621,56 @@ new file mode 100644
 index 000000000..3c92e11fb
 --- /dev/null
 +++ b/third_party/xla/0013-fix-multiple-definitions.patch
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,120 @@
 +From a37efb5841ca3c8f500659c4ae0608bfd6347a47 Mon Sep 17 00:00:00 2001
 +From: Eric Lundby <Eric.Lundby@gmail.com>
 +Date: Wed, 28 Jan 2026 08:14:46 -0700
-+Subject: [PATCH 1/1] 0013
++Subject: [PATCH 1/1] 0013 fix multiple definitions for jax 0.9.2 XLA
 +
-+ERROR: Flag 'leave_barriers_on_recoverable_agent_restart' was defined more than once but with differing types. Defined in files 'external/local_xla/xla/tsl/distributed_runtime/coordination/coordination_service.cc' and 'external/local_xla/xla/tsl/distributed_runtime/coordination/coordination_service.cc'.
++Prevent duplicate ABSL_FLAG registration when jaxlib and tensorflow-base
++are loaded together. Split coordination_service into impl + hdrs_only
++targets and switch header-only consumers to hdrs_only.
 +
-+See: https://github.com/AnacondaRecipes/tensorflow-feedstock/blob/main/recipe/patches/0022-fix-multiple-flag-defs.patch
++Rebased for jax 0.9.2 / XLA 187a5eb (pjrt/coordination split, new deps).
 +
 +---
-+ xla/pjrt/distributed/BUILD                    |  2 +-
 + xla/pjrt/gpu/BUILD                            |  2 +-
-+ .../distributed_runtime/coordination/BUILD    | 46 ++++++++++++++++++-
++ xla/runtime/BUILD                             |  2 +-
++ .../distributed_runtime/coordination/BUILD    | 45 ++++++++++++++++++-
 + .../rpc/coordination/BUILD                    |  2 +-
-+ 4 files changed, 48 insertions(+), 4 deletions(-)
++ 4 files changed, 47 insertions(+), 4 deletions(-)
 +
-+diff --git a/xla/pjrt/distributed/BUILD b/xla/pjrt/distributed/BUILD
-+index e8528f51b3..a177ca422b 100644
-+--- a/xla/pjrt/distributed/BUILD
-++++ b/xla/pjrt/distributed/BUILD
-+@@ -25,7 +25,7 @@ cc_library(
-+         ":util",
-+         "//xla:types",
-+         "//xla:util",
-+-        "//xla/tsl/distributed_runtime/coordination:coordination_service",
-++        "//xla/tsl/distributed_runtime/coordination:coordination_service_hdrs_only",
-+         "//xla/tsl/distributed_runtime/rpc:async_service_interface",
-+         "//xla/tsl/distributed_runtime/rpc/coordination:grpc_coordination_service_impl",
-+         "//xla/tsl/protobuf:coordination_config_proto_cc",
 +diff --git a/xla/pjrt/gpu/BUILD b/xla/pjrt/gpu/BUILD
-+index 41ccb2450a..5be365e31c 100644
++index f727328..952d8ab 100644
 +--- a/xla/pjrt/gpu/BUILD
 ++++ b/xla/pjrt/gpu/BUILD
-+@@ -122,7 +122,7 @@ cc_library(
++@@ -141,7 +141,7 @@ cc_library(
 +         "//xla/stream_executor/integrations:tf_allocator_adapter",
 +         "//xla/tsl/concurrency:async_value",
 +         "//xla/tsl/concurrency:ref_count",
 +-        "//xla/tsl/distributed_runtime/coordination:coordination_service",
 ++        "//xla/tsl/distributed_runtime/coordination:coordination_service_hdrs_only",
-+         "//xla/tsl/distributed_runtime/coordination:coordination_service_agent",
 +         "//xla/tsl/framework:allocator",
 +         "//xla/tsl/framework:bfc_allocator",
++         "//xla/tsl/framework:device_id",
++diff --git a/xla/runtime/BUILD b/xla/runtime/BUILD
++index e05400b..d766362 100644
++--- a/xla/runtime/BUILD
+++++ b/xla/runtime/BUILD
++@@ -187,7 +187,7 @@ cc_library(
++     name = "device_id",
++     hdrs = ["device_id.h"],
++     deps = [
++-        "//xla/tsl/distributed_runtime/coordination:coordination_service",
+++        "//xla/tsl/distributed_runtime/coordination:coordination_service_hdrs_only",
++         "//xla/tsl/lib/gtl:int_type",
++         "@com_google_absl//absl/strings",
++         "@com_google_absl//absl/strings:string_view",
 +diff --git a/xla/tsl/distributed_runtime/coordination/BUILD b/xla/tsl/distributed_runtime/coordination/BUILD
-+index 3429acaba3..a71d2d3a62 100644
++index 42c9d19..9f05841 100644
 +--- a/xla/tsl/distributed_runtime/coordination/BUILD
 ++++ b/xla/tsl/distributed_runtime/coordination/BUILD
-+@@ -50,7 +50,7 @@ cc_library(
++@@ -48,7 +48,7 @@ cc_library(
 + )
 + 
 + cc_library(
@@ -1677,11 +1679,10 @@ index 000000000..3c92e11fb
 +     srcs = ["coordination_service.cc"],
 +     hdrs = ["coordination_service.h"],
 +     deps = [
-+@@ -86,6 +86,50 @@ cc_library(
++@@ -84,6 +84,49 @@ cc_library(
 +     ],
 + )
 + 
-++ 
 ++cc_library(
 ++    name = "coordination_service",
 ++    deps = [":coordination_service_impl"],
@@ -1729,7 +1730,7 @@ index 000000000..3c92e11fb
 +     name = "test_device_proto",
 +     testonly = 1,
 +diff --git a/xla/tsl/distributed_runtime/rpc/coordination/BUILD b/xla/tsl/distributed_runtime/rpc/coordination/BUILD
-+index 4fe8e5015a..562fa8b777 100644
++index 74349c2..58f175c 100644
 +--- a/xla/tsl/distributed_runtime/rpc/coordination/BUILD
 ++++ b/xla/tsl/distributed_runtime/rpc/coordination/BUILD
 +@@ -36,7 +36,7 @@ cc_library(
@@ -1741,9 +1742,7 @@ index 000000000..3c92e11fb
 +         "//xla/tsl/distributed_runtime/coordination:coordination_service_agent",
 +         "//xla/tsl/distributed_runtime/coordination:coordination_service_rpc_handler",
 +         "//xla/tsl/distributed_runtime/rpc:async_service_interface",
-+-- 
-+2.50.1 (Apple Git-155)
-+diff --git a/third_party/xla/0014-Disable-leave-barriers-flag.patch b/third_party/xla/0014-Disable-leave-barriers-flag.patch
+diff --git a/third_party/xla/0014-Disable-leave-barriers-flag.patch b/third_party/xla/0014-Disable-leave-barriers-flag.patch
 new file mode 100644
 index 000000000..e102a6edb
 --- /dev/null

--- a/recipe/patches/0002-Consolidated-build-fixes-for-XLA.patch
+++ b/recipe/patches/0002-Consolidated-build-fixes-for-XLA.patch
@@ -26,8 +26,10 @@ Co-Authored-By: H. Vetinari <h.vetinari@gmx.com>
  .../0009-Add-macos_x86_64-to-mkl_deps.patch   |  21 +
  .../xla/0010-Add-systemlib-for-oneDNN.patch   | 103 ++++
  ...011-Fix-clang-CUDA-incompatabilities.patch |  64 +++
- third_party/xla/workspace.bzl                 |  11 +
- 13 files changed, 1510 insertions(+)
+ .../xla/0013-fix-multiple-definitions.patch   | 122 ++++++
+ .../0014-Disable-leave-barriers-flag.patch    |  65 +++
+ third_party/xla/workspace.bzl                 |  13 +
+ 15 files changed, 1697 insertions(+)
  create mode 100644 third_party/grpc_systemlib.BUILD
  create mode 100644 third_party/xla/0001-Fix-abseil-headers.patch
  create mode 100644 third_party/xla/0002-Omit-usage-of-StrFormat.patch
@@ -40,6 +42,8 @@ Co-Authored-By: H. Vetinari <h.vetinari@gmx.com>
  create mode 100644 third_party/xla/0009-Add-macos_x86_64-to-mkl_deps.patch
  create mode 100644 third_party/xla/0010-Add-systemlib-for-oneDNN.patch
  create mode 100644 third_party/xla/0011-Fix-clang-CUDA-incompatabilities.patch
+ create mode 100644 third_party/xla/0013-fix-multiple-definitions.patch
+ create mode 100644 third_party/xla/0014-Disable-leave-barriers-flag.patch
 
 diff --git a/third_party/grpc_systemlib.BUILD b/third_party/grpc_systemlib.BUILD
 new file mode 100644
@@ -1612,11 +1616,208 @@ index 0000000..4cc8949
 + 
 + __device__ unsigned int ThreadIdx() {
 +   return threadIdx.z * blockDim.y * blockDim.x + threadIdx.y * blockDim.x +
-diff --git a/third_party/xla/workspace.bzl b/third_party/xla/workspace.bzl
+diff --git a/third_party/xla/0013-fix-multiple-definitions.patch b/third_party/xla/0013-fix-multiple-definitions.patch
+new file mode 100644
+index 000000000..3c92e11fb
+--- /dev/null
++++ b/third_party/xla/0013-fix-multiple-definitions.patch
+@@ -0,0 +1,122 @@
++From a37efb5841ca3c8f500659c4ae0608bfd6347a47 Mon Sep 17 00:00:00 2001
++From: Eric Lundby <Eric.Lundby@gmail.com>
++Date: Wed, 28 Jan 2026 08:14:46 -0700
++Subject: [PATCH 1/1] 0013
++
++ERROR: Flag 'leave_barriers_on_recoverable_agent_restart' was defined more than once but with differing types. Defined in files 'external/local_xla/xla/tsl/distributed_runtime/coordination/coordination_service.cc' and 'external/local_xla/xla/tsl/distributed_runtime/coordination/coordination_service.cc'.
++
++See: https://github.com/AnacondaRecipes/tensorflow-feedstock/blob/main/recipe/patches/0022-fix-multiple-flag-defs.patch
++
++---
++ xla/pjrt/distributed/BUILD                    |  2 +-
++ xla/pjrt/gpu/BUILD                            |  2 +-
++ .../distributed_runtime/coordination/BUILD    | 46 ++++++++++++++++++-
++ .../rpc/coordination/BUILD                    |  2 +-
++ 4 files changed, 48 insertions(+), 4 deletions(-)
++
++diff --git a/xla/pjrt/distributed/BUILD b/xla/pjrt/distributed/BUILD
++index e8528f51b3..a177ca422b 100644
++--- a/xla/pjrt/distributed/BUILD
+++++ b/xla/pjrt/distributed/BUILD
++@@ -25,7 +25,7 @@ cc_library(
++         ":util",
++         "//xla:types",
++         "//xla:util",
++-        "//xla/tsl/distributed_runtime/coordination:coordination_service",
+++        "//xla/tsl/distributed_runtime/coordination:coordination_service_hdrs_only",
++         "//xla/tsl/distributed_runtime/rpc:async_service_interface",
++         "//xla/tsl/distributed_runtime/rpc/coordination:grpc_coordination_service_impl",
++         "//xla/tsl/protobuf:coordination_config_proto_cc",
++diff --git a/xla/pjrt/gpu/BUILD b/xla/pjrt/gpu/BUILD
++index 41ccb2450a..5be365e31c 100644
++--- a/xla/pjrt/gpu/BUILD
+++++ b/xla/pjrt/gpu/BUILD
++@@ -122,7 +122,7 @@ cc_library(
++         "//xla/stream_executor/integrations:tf_allocator_adapter",
++         "//xla/tsl/concurrency:async_value",
++         "//xla/tsl/concurrency:ref_count",
++-        "//xla/tsl/distributed_runtime/coordination:coordination_service",
+++        "//xla/tsl/distributed_runtime/coordination:coordination_service_hdrs_only",
++         "//xla/tsl/distributed_runtime/coordination:coordination_service_agent",
++         "//xla/tsl/framework:allocator",
++         "//xla/tsl/framework:bfc_allocator",
++diff --git a/xla/tsl/distributed_runtime/coordination/BUILD b/xla/tsl/distributed_runtime/coordination/BUILD
++index 3429acaba3..a71d2d3a62 100644
++--- a/xla/tsl/distributed_runtime/coordination/BUILD
+++++ b/xla/tsl/distributed_runtime/coordination/BUILD
++@@ -50,7 +50,7 @@ cc_library(
++ )
++ 
++ cc_library(
++-    name = "coordination_service",
+++    name = "coordination_service_impl",
++     srcs = ["coordination_service.cc"],
++     hdrs = ["coordination_service.h"],
++     deps = [
++@@ -86,6 +86,50 @@ cc_library(
++     ],
++ )
++ 
+++ 
+++cc_library(
+++    name = "coordination_service",
+++    deps = [":coordination_service_impl"],
+++    visibility = ["//visibility:public"],
+++)
+++
+++cc_library(
+++    name = "coordination_service_hdrs_only",
+++    hdrs = ["coordination_service.h"],
+++    deps = [
+++        ":coordination_client",
+++        ":coordination_service_error_util",
+++        ":key_value_store",
+++        "//xla/tsl/distributed_runtime:call_options",
+++        "//xla/tsl/lib/gtl:int_type",
+++        "//xla/tsl/platform:env",
+++        "//xla/tsl/platform:errors",
+++        "//xla/tsl/platform:status",
+++        "//xla/tsl/protobuf:coordination_config_proto_cc",
+++        "//xla/tsl/protobuf:coordination_service_proto_cc",
+++        "//xla/tsl/util:device_name_utils",
+++        "@com_google_absl//absl/algorithm:container",
+++        "@com_google_absl//absl/base:core_headers",
+++        "@com_google_absl//absl/container:flat_hash_map",
+++        "@com_google_absl//absl/container:flat_hash_set",
+++        "@com_google_absl//absl/flags:flag",
+++        "@com_google_absl//absl/functional:any_invocable",
+++        "@com_google_absl//absl/hash",
+++        "@com_google_absl//absl/log",
+++        "@com_google_absl//absl/log:check",
+++        "@com_google_absl//absl/status",
+++        "@com_google_absl//absl/status:statusor",
+++        "@com_google_absl//absl/strings",
+++        "@com_google_absl//absl/strings:str_format",
+++        "@com_google_absl//absl/strings:string_view",
+++        "@com_google_absl//absl/synchronization",
+++        "@com_google_absl//absl/time",
+++        "@com_google_absl//absl/types:span",
+++        "@tsl//tsl/platform:random",
+++    ],
+++    visibility = ["//visibility:public"],
+++)
+++
++ tf_proto_library(
++     name = "test_device_proto",
++     testonly = 1,
++diff --git a/xla/tsl/distributed_runtime/rpc/coordination/BUILD b/xla/tsl/distributed_runtime/rpc/coordination/BUILD
++index 4fe8e5015a..562fa8b777 100644
++--- a/xla/tsl/distributed_runtime/rpc/coordination/BUILD
+++++ b/xla/tsl/distributed_runtime/rpc/coordination/BUILD
++@@ -36,7 +36,7 @@ cc_library(
++     srcs = ["grpc_coordination_service_impl.cc"],
++     hdrs = ["grpc_coordination_service_impl.h"],
++     deps = [
++-        "//xla/tsl/distributed_runtime/coordination:coordination_service",
+++        "//xla/tsl/distributed_runtime/coordination:coordination_service_hdrs_only",
++         "//xla/tsl/distributed_runtime/coordination:coordination_service_agent",
++         "//xla/tsl/distributed_runtime/coordination:coordination_service_rpc_handler",
++         "//xla/tsl/distributed_runtime/rpc:async_service_interface",
++-- 
++2.50.1 (Apple Git-155)
++diff --git a/third_party/xla/0014-Disable-leave-barriers-flag.patch b/third_party/xla/0014-Disable-leave-barriers-flag.patch
+new file mode 100644
+index 000000000..e102a6edb
+--- /dev/null
++++ b/third_party/xla/0014-Disable-leave-barriers-flag.patch
+@@ -0,0 +1,65 @@
++From 8f8c5d36414a638ab2e1906975a5b609669a1cdb Mon Sep 17 00:00:00 2001
++From: Eric Lundby <Eric.Lundby@gmail.com>
++Date: Wed, 28 Jan 2026 14:53:54 -0700
++Subject: [PATCH 1/1] 14
++
++---
++ .../coordination/coordination_service.cc           | 14 +++++++-------
++ 1 file changed, 7 insertions(+), 7 deletions(-)
++
++diff --git a/xla/tsl/distributed_runtime/coordination/coordination_service.cc b/xla/tsl/distributed_runtime/coordination/coordination_service.cc
++index 8667719a50..ddf8d82056 100644
++--- a/xla/tsl/distributed_runtime/coordination/coordination_service.cc
+++++ b/xla/tsl/distributed_runtime/coordination/coordination_service.cc
++@@ -53,9 +53,9 @@ limitations under the License.
++ #include "xla/tsl/protobuf/coordination_service.pb.h"
++ #include "xla/tsl/util/device_name_utils.h"
++ 
++-ABSL_FLAG(bool, leave_barriers_on_recoverable_agent_restart, false,
++-          "If true, allow the recoverable agent to leave ongoing barriers on "
++-          "restart.");
+++// ABSL_FLAG(bool, leave_barriers_on_recoverable_agent_restart, false,
+++//           "If true, allow the recoverable agent to leave ongoing barriers on "
+++//           "restart.");
++ 
++ namespace tsl {
++ namespace {
++@@ -312,7 +312,7 @@ CoordinationService::GetCountOfOutOfSyncTasksPerBarrier() {
++ }
++ 
++ void CoordinationService::CheckBarrierStatusWithRecoverableTasks() {
++-  if (!absl::GetFlag(FLAGS_leave_barriers_on_recoverable_agent_restart)) {
+++  if (!false) {
++     return;
++   }
++ 
++@@ -555,7 +555,7 @@ void CoordinationService::ConnectTask(const CoordinatedTask& task,
++   task_state->Connect();
++   if (task_state->IsRecoverable()) {
++     LeaveOngoingBarriers(task, "recoverable task silently connected again");
++-    if (absl::GetFlag(FLAGS_leave_barriers_on_recoverable_agent_restart)) {
+++    if (false) {
++       unsynced_recoverable_jobs_.insert(task_name);
++     }
++   }
++@@ -619,7 +619,7 @@ void CoordinationService::RegisterTaskAsync(const CoordinatedTask& task,
++       // again. When the task passes a barrier with other tasks, it will be
++       // removed from the unsynced set.
++       if (task_cluster_state->IsRecoverable() &&
++-          absl::GetFlag(FLAGS_leave_barriers_on_recoverable_agent_restart)) {
+++          false) {
++         if (barriers_.contains(kClusterRegisterBarrierId) &&
++             barriers_[kClusterRegisterBarrierId].passed) {
++           // We want to mark the task unsynced when it connects again. When the
++@@ -1723,7 +1723,7 @@ void CoordinationService::LeaveOngoingBarriers(const CoordinatedTask& task,
++     for (const auto& barrier_id : task_state->GetOngoingBarriers()) {
++       BarrierState* barrier = &barriers_[barrier_id];
++       // Unregister task from barrier.
++-      if (absl::GetFlag(FLAGS_leave_barriers_on_recoverable_agent_restart)) {
+++      if (false) {
++         if (barrier->tasks_at_barrier.contains(task)) {
++           // Remove task from barrier.
++           barrier->recoverable_tasks_restarted_during_barrier.insert(task);
++-- 
++2.50.1 (Apple Git-155)
++diff --git a/third_party/xla/workspace.bzl b/third_party/xla/workspace.bzl
 index 8c9d53c..eea3172 100644
 --- a/third_party/xla/workspace.bzl
 +++ b/third_party/xla/workspace.bzl
-@@ -27,6 +27,17 @@ def repo():
+@@ -27,6 +27,19 @@ def repo():
              "//third_party/xla:xla_gpu_cublaslt_default.patch",
              "//third_party/xla:xla_gpu_cublaslt_algorithm3.patch",
  	    "//third_party/xla:xla_nccl_comm_split_deadlock.patch",
@@ -1631,6 +1832,8 @@ index 8c9d53c..eea3172 100644
 +            "//third_party/xla:0009-Add-macos_x86_64-to-mkl_deps.patch",
 +            "//third_party/xla:0010-Add-systemlib-for-oneDNN.patch",
 +            "//third_party/xla:0011-Fix-clang-CUDA-incompatabilities.patch",
++            "//third_party/xla:0013-fix-multiple-definitions.patch",
++            "//third_party/xla:0014-Disable-leave-barriers-flag.patch",
          ],
      )
  


### PR DESCRIPTION
jaxlib rebuild

**Destination channel:** defaults

### Links

- [PKG-16235](https://anaconda.atlassian.net/browse/PKG-16235) 

### Explanation of changes:

- Add back patches from #23 to fix problems mixing jax and tensorflow, as seen in keras (again)


[PKG-16235]: https://anaconda.atlassian.net/browse/PKG-16235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ